### PR TITLE
fix(core): invoke _doCompaction callback exactly once

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -748,10 +748,10 @@ function SqlPouch(opts: OpenDatabaseOptions, cb: (err: any) => void) {
         await tx.execute(sql, [safeJsonStringify(metadata), docId])
 
         await compactRevs(revs, docId, tx)
+        callback()
       } catch (e: any) {
         handleSQLiteError(e, callback)
       }
-      callback()
     })
   }
 


### PR DESCRIPTION
## Problem

In `api._doCompaction` (`src/core.ts`), `callback()` is invoked unconditionally **after** the `try/catch` block:

```ts
try {
  // ...
  await compactRevs(revs, docId, tx)
} catch (e: any) {
  handleSQLiteError(e, callback)   // <-- already invokes callback(error)
}
callback()                         // <-- fires again, even on the error path
```

`handleSQLiteError` always calls the supplied callback. So on the error path the callback fires **twice** — once with the error, then again with no arguments. The second (success-looking) call can mask the real failure and corrupt PouchDB's internal compaction bookkeeping, since the framework treats compaction as having succeeded.

## How it shows up

We hit this once the local client enabled `auto_compaction`. `compactRevs` performs additional `tx.execute()` calls inside its orphan-attachment deletes; if those run against a finalized transaction the throw lands in the `catch`, and the trailing `callback()` then reports success over the top of it:

```
Error: Cannot execute on finalized transaction
    at compactRevs (...)
```

The genuine error was swallowed because the second callback invocation overwrote it.

## Fix

Move `callback()` inside the `try`, right after `await compactRevs(...)`, so it fires **exactly once** — on success here, and left to `handleSQLiteError` on failure:

```ts
try {
  // ...
  await compactRevs(revs, docId, tx)
  callback()
} catch (e: any) {
  handleSQLiteError(e, callback)
}
```

One-line change. `npx tsc --noEmit` passes. Opening as a draft for maintainer review — happy to add a regression test if you'd like one.